### PR TITLE
Add Kubernetes login function

### DIFF
--- a/features.md
+++ b/features.md
@@ -332,6 +332,11 @@
 `POST /auth/{{mount_point}}{{^mount_point}}approle{{/mount_point}}/login`
 
 
+## vault.kubernetesLogin
+
+`POST /auth/kubernetes/login`
+
+
 ## vault.health
 
 `GET /sys/health`

--- a/src/commands.js
+++ b/src/commands.js
@@ -1097,6 +1097,25 @@ module.exports = {
       res: approleResponse,
     },
   },
+  kubernetesLogin: {
+    method: 'POST',
+    path: '/auth/kubernetes/login',
+    schema: {
+      req: {
+        type: 'object',
+        properties: {
+          role: {
+            type: 'string',
+          },
+          jwt: {
+            type: 'string',
+          },
+        },
+        required: ['role', 'jwt'],
+      },
+      res: approleResponse,
+    },
+  },
   health: {
     method: 'GET',
     path: '/sys/health',


### PR DESCRIPTION
Dustin on Kubernetes Vault at Banno:

> So, vault in Kubernetes works a little bit differently. We use https://www.vaultproject.io/api/auth/kubernetes/index.html#login to auth to Vault instead of the app role way. That jwt token should be available at the filesystem path `/var/run/secrets/kubernetes.io/serviceaccount/token`. So you’ll need to read that path and then auth with that token instead of just the role name. We’ll also need to get the app setup in Kubernetes which is different from the LKS ones, but I don’t think we have just a script for you to run for that right now.
